### PR TITLE
Fix crash with Opus stream

### DIFF
--- a/Citric Composer/Citric Composer/EditorBase.cs
+++ b/Citric Composer/Citric Composer/EditorBase.cs
@@ -4133,7 +4133,8 @@ namespace Citric_Composer {
             this.stmStreamType.Items.AddRange(new object[] {
             "Invalid",
             "Binary",
-            "ADTS"});
+            "ADTS",
+            "Opus"});
             this.stmStreamType.Location = new System.Drawing.Point(7, 280);
             this.stmStreamType.Name = "stmStreamType";
             this.stmStreamType.Size = new System.Drawing.Size(276, 21);

--- a/Citric Composer/Citric Composer/High Level/Sound Archive/SoundArchiveReader.cs
+++ b/Citric Composer/Citric Composer/High Level/Sound Archive/SoundArchiveReader.cs
@@ -1192,7 +1192,16 @@ namespace CitraFileLoader {
                                         } else {
                                             FileReader.JumpToReference(br, "StreamSoundExtensionRef");
                                             m.SoundExtensionIncluded = true;
-                                            m.StreamFileType = (StreamEntry.EStreamFileType)br.ReadUInt32();
+
+                                            // FileType = static_cast<SoundArchive::StreamFileType>( Util::DevideBy8bit( streamTypeInfo, 0 ) );
+                                            m.StreamFileType = (StreamEntry.EStreamFileType)(br.ReadUInt32() & 0xff);
+                                            if (m.StreamFileType > StreamEntry.EStreamFileType.Max) {
+                                                throw new IndexOutOfRangeException();
+                                            }
+
+                                            // TODO: IsLoop = Util::DevideBy8bit( streamTypeInfo, 1 ) == 1;
+                                            // TODO: Unknown = Util::DevideBy8bit( streamTypeInfo, 2 );
+
                                             m.LoopStartFrame = br.ReadUInt32();
                                             m.LoopEndFrame = br.ReadUInt32();
                                         }

--- a/Citric Composer/Citric Composer/High Level/Sound Archive/StreamEntry.cs
+++ b/Citric Composer/Citric Composer/High Level/Sound Archive/StreamEntry.cs
@@ -135,7 +135,8 @@ namespace CitraFileLoader {
         /// Stream file type.
         /// </summary>
         public enum EStreamFileType : uint {
-            Invalid, Binary, ADTS
+            Invalid, Binary, ADTS, Opus,
+            Max = Opus,
         };
 
     }


### PR DESCRIPTION
I opened bfsar with Opus stream, clicked stream name under `Sound Streams` section of tree view, then app crashed.

Fixed parsing of `StreamFileType` according to [this comment](https://github.com/Gota7/Citric-Composer/blob/a010479cf5468a2406819ee66892ce842383a5f3/Citric%20Composer/Citric%20Composer/SoundArchive.cs#L1395) and it worked.  
And added range checking to catch bugs early if new values ​​are added to StreamFileType in the future.

Also I noticed that there is unknown value in 3rd byte, So I left comment for it.
