### PR TITLE
Sound Streams naming fix

### DIFF
--- a/Citric Composer/Citric Composer/MainWindow.cs
+++ b/Citric Composer/Citric Composer/MainWindow.cs
@@ -3087,7 +3087,7 @@ namespace Citric_Composer {
             string h = Microsoft.VisualBasic.Interaction.InputBox("New Name", "Enter Name:", tree.SelectedNode.Text.Split(']')[1].Substring(1));
             if (h != "") {
                 string node = tree.SelectedNode.Parent.Name;
-                if (node.Equals("stream")) {
+                if (node.Equals("streams")) {
                     File.Streams[tree.SelectedNode.Index].Name = h;
                 } else if (node.Equals("sequences")) {
                     File.Sequences[tree.SelectedNode.Index].Name = h;
@@ -3358,9 +3358,32 @@ namespace Citric_Composer {
                 if (f.FileId == -2) {
                     f = null;
                 }
+                string fileName = f.ExternalFileName;
+                if (fileName != null) {
+                    int dashIdx = fileName.LastIndexOf("/");
+                    if (dashIdx == -1) fileName.LastIndexOf("\\");
+                    fileName = fileName.Substring(dashIdx + 1);
+                    int pathIdx = fileName.LastIndexOf(".");
+                    if (pathIdx != -1)
+                    {
+                        fileName = fileName.Substring(0, pathIdx);
+                    }
+                }
+                else
+                {
+                    fileName = f.FileName;
+                }
+                foreach (StreamEntry testEntry in File.Streams)
+                {
+                    if (testEntry.Name.CompareTo(fileName) == 0)
+                    {
+                        fileName = "STM_" + index;
+                        break;
+                    }
+                }
 
                 //New entry.
-                StreamEntry e = new StreamEntry() { Name = "STM_" + index, File = f, Player = File.Players[0], Sound3dInfo = new Sound3dInfo() };
+                StreamEntry e = new StreamEntry() { Name = fileName, File = f, Player = File.Players[0], Sound3dInfo = new Sound3dInfo() };
                 File.Streams.Insert(index, e);
 
                 //Manage sound sets.

--- a/Citric Composer/Citric Composer/MainWindow.cs
+++ b/Citric Composer/Citric Composer/MainWindow.cs
@@ -3358,21 +3358,7 @@ namespace Citric_Composer {
                 if (f.FileId == -2) {
                     f = null;
                 }
-                string fileName = f.ExternalFileName;
-                if (fileName != null) {
-                    int dashIdx = fileName.LastIndexOf("/");
-                    if (dashIdx == -1) fileName.LastIndexOf("\\");
-                    fileName = fileName.Substring(dashIdx + 1);
-                    int pathIdx = fileName.LastIndexOf(".");
-                    if (pathIdx != -1)
-                    {
-                        fileName = fileName.Substring(0, pathIdx);
-                    }
-                }
-                else
-                {
-                    fileName = f.FileName;
-                }
+                string fileName = (f.ExternalFileName != null) ? Path.GetFileNameWithoutExtension(f.ExternalFileName) : f.FileName;
                 foreach (StreamEntry testEntry in File.Streams)
                 {
                     if (testEntry.Name.CompareTo(fileName) == 0)


### PR DESCRIPTION
This PR fixes a typo in `SarRename_Click` that prevents the user from renaming any Sound Streams and changes `CreateStream` to try to give to the newly created Sound Stream a name that corresponds to it's original file name.